### PR TITLE
fix: resolved bug on wrong sync for payment types

### DIFF
--- a/src/test/java/it/pagopa/afm/marketplacebe/service/PaymentTypeServiceTest.java
+++ b/src/test/java/it/pagopa/afm/marketplacebe/service/PaymentTypeServiceTest.java
@@ -17,12 +17,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.*;
 
-import static it.pagopa.afm.marketplacebe.TestUtil.getMockPaymentTypeList;
-import static it.pagopa.afm.marketplacebe.TestUtil.getMockPaymentTypeListForCreate;
+import static it.pagopa.afm.marketplacebe.TestUtil.*;
 import static it.pagopa.afm.marketplacebe.exception.AppError.PAYMENT_TYPE_NOT_DELETABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,31 +72,136 @@ class PaymentTypeServiceTest {
     }
 
     @Test
-    void shouldUploadPaymentTypeList() {
-        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypeEntityList = getMockPaymentTypeList();
-        it.pagopa.afm.marketplacebe.entity.PaymentType paymentType = TestUtil.getMockPaymentType();
+    void shouldUploadPaymentTypeList_emptyInputEmptyDBNoBundle() {
+        // test case: empty input list, empty element list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = new ArrayList<>();
+        when(paymentTypeRepository.findAll()).thenReturn(Collections.emptyList());
         // preconditions
-        when(paymentTypeRepository.findByName(anyString())).thenReturn(Optional.of(paymentType));
-        when(bundleRepository.findByPaymentType(paymentType.getName())).thenReturn(List.of());
-        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypeEntityList);
+        when(bundleRepository.findByPaymentType(anyString())).thenReturn(List.of()); // no bundle
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
         // tests
-        paymentTypeService.syncPaymentTypes(paymentTypeEntityList);
-        verify(paymentTypeRepository).saveAll(paymentTypeArgumentCaptor.capture());
-        // assertions
-        Mockito.verify(paymentTypeRepository, times(1)).saveAll(Mockito.any());
-        assertEquals(paymentTypeEntityList.size(), paymentTypeArgumentCaptor.getValue().size());
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
+    }
+
+    @Test
+    void shouldUploadPaymentTypeList_samePaymentTypesWithBundle() {
+        // test case: single element (A) input list, single element (A with bundle) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = getMockPaymentTypeList();
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = getMockPaymentTypeList();
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
+        // preconditions
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of(TestUtil.getMockBundle())); // bundle for A
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
+        // tests
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
+    }
+
+    @Test
+    void shouldUploadPaymentTypeList_differentPaymentTypesNoBundle() {
+        // test case: single element (A) input list, single element (B with no bundle) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = getMockPaymentTypeList();
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = getMockPaymentTypeList();
+        paymentTypesAsDBResult.get(0).setName("PPAL");
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
+        // preconditions
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of()); // no bundle
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
+        // tests
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
+    }
+
+    @Test
+    void shouldUploadPaymentTypeList_dbSubsetOfInputWithBundle() {
+        // test case: element (A, B) input list, single element (A with bundle) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = new ArrayList<>();
+        paymentTypesAsInput.add(getMockPaymentType());
+        paymentTypesAsInput.add(it.pagopa.afm.marketplacebe.entity.PaymentType.builder()
+                .id(UUID.randomUUID().toString())
+                .name("PPAL")
+                .createdDate(LocalDateTime.now()).build());
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = getMockPaymentTypeList();
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
+        // preconditions
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of(TestUtil.getMockBundle()));
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
+        // tests
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
+    }
+
+    @Test
+    void shouldUploadPaymentTypeList_dbSubsetOfInputNoBundle() {
+        // test case: element (A, B) input list, single element (A with bundle) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = new ArrayList<>();
+        paymentTypesAsInput.add(getMockPaymentType());
+        paymentTypesAsInput.add(it.pagopa.afm.marketplacebe.entity.PaymentType.builder()
+                .id(UUID.randomUUID().toString())
+                .name("PPAL")
+                .createdDate(LocalDateTime.now()).build());
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = getMockPaymentTypeList();
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
+        // preconditions
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of());
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
+        // tests
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
+    }
+
+    @Test
+    void shouldUploadPaymentTypeList_inputSubsetOfDBWithBundle() {
+        // test case: element (A) input list, single element (A with bundle, B) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = getMockPaymentTypeList();
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = new ArrayList<>();
+        paymentTypesAsDBResult.add(getMockPaymentType());
+        paymentTypesAsDBResult.add(it.pagopa.afm.marketplacebe.entity.PaymentType.builder()
+                .id(UUID.randomUUID().toString())
+                .name("PPAL")
+                .createdDate(LocalDateTime.now()).build());
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
+        // preconditions
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of(TestUtil.getMockBundle()));
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
+        // tests
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
+    }
+
+    @Test
+    void shouldUploadPaymentTypeList_inputSubsetOfDBNoBundle() {
+        // test case: element (A) input list, single element (A with bundle, B) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = getMockPaymentTypeList();
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = new ArrayList<>();
+        paymentTypesAsDBResult.add(getMockPaymentType());
+        paymentTypesAsDBResult.add(it.pagopa.afm.marketplacebe.entity.PaymentType.builder()
+                .id(UUID.randomUUID().toString())
+                .name("PPAL")
+                .createdDate(LocalDateTime.now()).build());
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
+        // preconditions
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of());
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
+        // tests
+        executeTestForSyncPaymentTypes(paymentTypesAsInput);
     }
 
     @Test
     void shouldRaiseBadRequestWithNotDeletablePaymentType() {
-        it.pagopa.afm.marketplacebe.entity.PaymentType paymentType = TestUtil.getMockPaymentType();
+        // test case: element (B) input list, single element (A with bundle) list from DB
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput = getMockPaymentTypeList();
+        paymentTypesAsInput.get(0).setName("PPAL");
+        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsDBResult = getMockPaymentTypeList();
+        when(paymentTypeRepository.findAll()).thenReturn(paymentTypesAsDBResult);
         // preconditions
-        when(paymentTypeRepository.findByName(anyString())).thenReturn(Optional.of(paymentType));
-        when(bundleRepository.findByPaymentType(paymentType.getName())).thenReturn(List.of(TestUtil.getMockBundle()));
+        when(bundleRepository.findByPaymentType(paymentTypesAsDBResult.get(0).getName())).thenReturn(List.of(TestUtil.getMockBundle()));
+        when(paymentTypeRepository.saveAll(Mockito.any())).thenReturn(paymentTypesAsInput);
         // tests and assertions
-        List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypeList = List.of(paymentType);
-        AppException exception = assertThrows(AppException.class, () -> paymentTypeService.syncPaymentTypes(paymentTypeList));
+        AppException exception = assertThrows(AppException.class, () -> paymentTypeService.syncPaymentTypes(paymentTypesAsInput));
         assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
         assertEquals(PAYMENT_TYPE_NOT_DELETABLE.getTitle(), exception.getTitle());
+    }
+
+    void executeTestForSyncPaymentTypes(List<it.pagopa.afm.marketplacebe.entity.PaymentType> paymentTypesAsInput) {
+        paymentTypeService.syncPaymentTypes(paymentTypesAsInput);
+        verify(paymentTypeRepository).saveAll(paymentTypeArgumentCaptor.capture());
+        Mockito.verify(paymentTypeRepository, times(1)).saveAll(Mockito.any());
+        assertEquals(paymentTypesAsInput.size(), paymentTypeArgumentCaptor.getValue().size());
     }
 }


### PR DESCRIPTION
During an integration test with APIConfig, the syncronization of payment types ended in error due to the fact that AFM Marketplace cannot analyze correctly the payment types with associated bundles. With this PR, the bug is resolved including a check on bundles for the existing payment types that will be removed in the syncronization operation. 

#### List of Changes
 - Added check on the bundles for the payment types not included in list passed as input
 - Added more and more JUnit tests in order to analyze every possible inputs and cases 

#### Motivation and Context
This change is required in order to resolve the bug related to the syncronization of payment type configuration.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.